### PR TITLE
add default height and width values, enforce minimum dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,16 @@ $ make
 ```bash
 trekscii [height] [width]
 ```
+
+`height` and `width` must be larger than `16` and `46`, respectively. If not
+specified, they will default to half the respective terminal dimension.
+
 e.g.
 
 ```bash
-trekscii 25 85
+trekscii 25 85                         # fixed dimensions
 trekscii 35 $(tput cols)               # terminal width, fixed height
 trekscii $(tput lines) $(tput cols)    # full-terminal
+trekscii $(tput lines)                 # full-terminal height, half-terminal width
+trekscii                               # half-terminal height, half-terminal width
 ```

--- a/src/trekscii.cpp
+++ b/src/trekscii.cpp
@@ -1,7 +1,9 @@
 #include <iostream>
+#include <sys/ioctl.h>
 #include "trekscii.h"
 
-
+#define MIN_WIDTH 46
+#define MIN_HEIGHT 16
 
 int main(int argc, char** argv) {
 
@@ -11,10 +13,34 @@ int main(int argc, char** argv) {
     fread(&seed, 4, 1, devrnd);
     fclose(devrnd);
     srand(seed);
-    
 
-    int dimY = std::stoi(argv[1]);
-    int dimX = std::stoi(argv[2]);
+    // get window size
+    struct winsize w;
+    ioctl(0, TIOCGWINSZ, &w);
+
+    int dimY;
+    if (argc >= 2) {
+        dimY = std::stoi(argv[1]);
+        if (dimY < MIN_HEIGHT) {
+            std::cerr << "Error: height must be at least " << MIN_HEIGHT << std::endl;
+            return 1;
+        }
+    } else {
+        // default to half terminal height, with MIN_HEIGHT min
+        dimY = std::max(w.ws_row / 2, MIN_HEIGHT);
+    }
+
+    int dimX;
+    if (argc >= 3) {
+        dimX = std::stoi(argv[2]);
+        if (dimX < MIN_WIDTH) {
+            std::cerr << "Error: width must be at least " << MIN_WIDTH << std::endl;
+            return 1;
+        }
+    } else {
+        // default to half terminal width, with MIN_WIDTH min
+        dimX = std::max(w.ws_col / 2, MIN_WIDTH);
+    }
 
     Canvas canvas = Canvas(dimX, dimY - 2);
     canvas.generate();


### PR DESCRIPTION
Hey!

Thanks for this sweet program, the arts look amazing! :)

As to avoid having to always specify the dimensions, I ended up making a wrapper script; I noticed other people also do make one. Another issue is that it seems dimensions smaller than (46, 16) almost always end up in a crash (because of the art dimensions).

I think it makes sense to have a sane default when `height` and/or `width` are ommited. I implemented each dimension default value as `max(half a terminal, min uncrashable const)`. I've also added a check that will error out with a friendlier message when the specified dimensions will probably lead to a crash.

Thanks!